### PR TITLE
Raw packet mode and interceptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INPUT_DIR=./src
 OUTPUT_DIR=./dist
 EMCC_OPTS=-O3 --llvm-lto 1 --memory-init-file 0 -s NO_DYNAMIC_EXECUTION=1 -s NO_FILESYSTEM=1
-DEFAULT_EXPORTS:='_free','_malloc'
+DEFAULT_EXPORTS:='_free','_malloc','_exp2'
 
 LIBOPUS_ENCODER_SRC=$(INPUT_DIR)/encoderWorker.js
 LIBOPUS_DECODER_SRC=$(INPUT_DIR)/decoderWorker.js
@@ -21,11 +21,14 @@ LIBSPEEXDSP_EXPORTS:='_speex_resampler_init','_speex_resampler_process_interleav
 RECORDER=$(OUTPUT_DIR)/recorder.min.js
 RECORDER_SRC=$(INPUT_DIR)/recorder.js
 
+INTERCEPTOR=$(OUTPUT_DIR)/interceptor.min.js
+INTERCEPTOR_SRC=$(INPUT_DIR)/interceptor.js
+
 WAVE_WORKER=$(OUTPUT_DIR)/waveWorker.min.js
 WAVE_WORKER_SRC=$(INPUT_DIR)/waveWorker.js
 
 
-default: $(LIBOPUS_ENCODER) $(LIBOPUS_DECODER) $(RECORDER) $(WAVE_WORKER) test
+default: $(LIBOPUS_ENCODER) $(LIBOPUS_DECODER) $(RECORDER) $(INTERCEPTOR) $(WAVE_WORKER) test
 
 clean:
 	rm -rf $(OUTPUT_DIR) $(LIBOPUS_DIR) $(LIBSPEEXDSP_DIR)
@@ -62,6 +65,9 @@ $(LIBOPUS_DECODER): $(LIBOPUS_DECODER_SRC) $(LIBOPUS_OBJ) $(LIBSPEEXDSP_OBJ)
 
 $(RECORDER): $(RECORDER_SRC)
 	npm run uglify -- $(RECORDER_SRC) -c -m -o $@
+
+$(INTERCEPTOR): $(INTERCEPTOR_SRC)
+	npm run uglify -- $(INTERCEPTOR_SRC) -c -m -o $@
 
 $(WAVE_WORKER): $(WAVE_WORKER_SRC)
 	npm run uglify -- $(WAVE_WORKER_SRC) -c -m -o $@

--- a/example/interceptor.html
+++ b/example/interceptor.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Ogg Opus Encoder Example</title>
+  <script src="../src/interceptor.js"></script>
+  <style type='text/css'>
+    ul { list-style: none; }
+    li { margin: 1em; }
+    span { border: 1px dashed; cursor: pointer; }
+  </style>
+</head>
+<body>
+
+  <h1>Interceptor example</h1>
+  <p>Before you enable monitoring, make sure to either plug in headphones or turn the volume down.</p>
+  <p>This ogg opus implementation does not support more than 2 channels.</p>
+
+  <h2>Options</h2>
+
+  <div>
+    <label>monitorGain</label>
+    <input id="monitorGain" type="number" value="0" />
+  </div>
+
+  <div>
+    <label>numberOfChannels</label>
+    <input id="numberOfChannels" type="number" value="1" />
+  </div>
+
+  <div>
+    <label>encoderSampleRate</label>
+    <input id="encoderSampleRate" type="number" value="48000" />
+  </div>
+
+  <div>
+    <label>bitRate</label>
+    <input id="bitRate" type="number" value="64000" /> 
+  </div>
+
+  <div>
+    <label>maxBuffersPerPage</label>
+    <input id="maxBuffersPerPage" type="number" value="40" />
+  </div>
+
+  <div>
+    <label>encoderApplication</label>
+    <input id="encoderApplication" type="number" value="2049" />
+    <span onclick="encoderApplication.value=2048">VoIP</span>
+    <span onclick="encoderApplication.value=2049">Audio</span>
+    <span onclick="encoderApplication.value=2051">LowDelay</span>
+  </div>
+
+  <div>
+    <label>encoderFrameSize</label>
+    <input id="encoderFrameSize" type="number" value="20" />
+  </div>
+
+  <div>
+    <label>bufferLength</label>
+    <input id="bufferLength" type="number" value="256" />
+    <span onclick="bufferLength.value=256">256</span>
+    <span onclick="bufferLength.value=512">512</span>
+    <span onclick="bufferLength.value=1024">1024</span>
+    <span onclick="bufferLength.value=2048">2048</span>
+    <span onclick="bufferLength.value=4096">4096</span>
+    <span onclick="bufferLength.value=8192">8192</span>
+    <span onclick="bufferLength.value=16384">16384</span>
+  </div>
+
+  <div>
+    <label>rawPacket</label>
+    <input id="rawPacket" type="checkbox" checked/>
+  </div>
+
+  <div>
+    <label>autoStart</label>
+    <input id="autoStart" type="checkbox" checked/>
+  </div>
+
+  <div>
+    <label>enableStats</label>
+    <input id="enableStats" type="checkbox" checked/>
+  </div>
+
+  <h2>Commands</h2>
+  <button id="init">init</button>
+  <p>Capture</p>
+  <div>
+  <button id="start" disabled>start</button>
+  <button id="pause" disabled>pause</button>
+  <button id="resume" disabled>resume</button>
+  <button id="stopButton" disabled>stop</button>
+  </div>
+  <p>Playback</p>
+  <button id="renderPause" disabled>pause</button>
+  <button id="renderResume" disabled>resume</button>
+  <button id="renderFForward" disabled>fast forward</button>
+  <div>
+  </div>
+
+  <h2>Stats</h2>
+  <div>
+    <label>Playback idle counter:</label>
+    <label id="piCounter">0</pre>
+  </div>
+
+  <div>
+    <label>Playback buffer length:</label>
+    <label id="pbLength">0</pre>
+  </div>
+
+  <h2>Log</h2>
+  <pre id="log"></pre>
+
+  <script>
+    var interceptor;
+
+    start.addEventListener( "click", function(){ interceptor.start(); });
+    pause.addEventListener( "click", function(){ interceptor.pause(); });
+    resume.addEventListener( "click", function(){ interceptor.resume(); });
+    stopButton.addEventListener( "click", function(){ interceptor.stop(); });
+    renderPause.addEventListener( "click", function(){ interceptor.renderPause(); });
+    renderResume.addEventListener( "click", function(){ interceptor.renderResume(); });
+    renderFForward.addEventListener( "click", function(){ interceptor.renderFForward(); });
+    init.addEventListener( "click", function(){
+
+      if (!Interceptor.isRecordingSupported()) {
+        return screenLogger("Recording features are not supported in your browser.");
+      }
+
+      interceptor = new Interceptor({
+        monitorGain: parseInt(monitorGain.value, 10),
+        numberOfChannels: parseInt(numberOfChannels.value, 10),
+        bitRate: parseInt(bitRate.value, 10),
+        encoderSampleRate: parseInt(encoderSampleRate.value, 10),
+        maxBuffersPerPage: parseInt(maxBuffersPerPage.value, 10),
+        encoderFrameSize: parseInt(encoderFrameSize.value, 10),
+        bufferLength: parseInt(bufferLength.value, 10),
+        rawPacket: rawPacket.checked,
+        encoderPath: "../dist/encoderWorker.min.js",
+        decoderPath: "../dist/decoderWorker.min.js"
+      });
+
+      interceptor.addEventListener( "start", function(e){
+        screenLogger('Recorder is started');
+        init.disabled = start.disabled = resume.disabled = true;
+        pause.disabled = stopButton.disabled = false;
+      });
+
+      interceptor.addEventListener( "stop", function(e){
+        screenLogger('Recorder is stopped');
+        init.disabled = false;
+        pause.disabled = resume.disabled = stopButton.disabled = start.disabled = true;
+        renderPause.disabled = renderResume.disabled = renderFForward.disabled = true;
+      });
+
+      interceptor.addEventListener( "pause", function(e){
+        screenLogger('Recorder is paused');
+        init.disabled = pause.disabled = start.disabled = true;
+        resume.disabled = stopButton.disabled = false;
+      });
+
+      interceptor.addEventListener( "resume", function(e){
+        screenLogger('Recorder is resuming');
+        init.disabled = start.disabled = resume.disabled = true;
+        pause.disabled = stopButton.disabled = false;
+      });
+
+      interceptor.addEventListener( "rpause", function(e){
+        screenLogger('Playback is paused');
+        renderPause.disabled = true;
+        renderResume.disabled = false;
+      });
+
+      interceptor.addEventListener( "rresume", function(e){
+        screenLogger('Playback is resuming');
+        renderResume.disabled = true;
+        renderPause.disabled = false;
+      });
+
+      if (enableStats.checked){
+        interceptor.addEventListener( "ridle", function(e){
+          piCounter.innerHTML = e.detail;
+        });
+
+        interceptor.addEventListener( "rqupdate", function(e){
+          pbLength.innerHTML = e.detail;
+        });
+      }
+
+      interceptor.addEventListener( "rfforward", function(e){
+        screenLogger('Playback fast forward');
+      });
+
+      interceptor.addEventListener( "streamError", function(e){
+        screenLogger('Error encountered: ' + e.error.name );
+      });
+
+      interceptor.addEventListener( "streamReady", function(e){
+        init.disabled = pause.disabled = resume.disabled = stopButton.disabled = true;
+        start.disabled = false;
+        screenLogger('Audio stream is ready.');
+
+        if (autoStart.checked){
+          interceptor.start();
+        }
+      });
+
+      interceptor.addEventListener( "dataAvailable", function(e){
+        interceptor.feedData(e.detail);
+      });
+
+      interceptor.initStream();
+      renderPause.disabled = renderFForward.disabled = false;
+
+    });
+
+    function screenLogger(text, data) {
+      log.innerHTML += "\n" + text + " " + (data || '');
+    }
+
+  </script>
+</body>
+</html>

--- a/src/encoderWorker.js
+++ b/src/encoderWorker.js
@@ -102,7 +102,7 @@ var root = (typeof self === 'object' && self.self === self && self) || (typeof g
   OggOpusEncoder.prototype.encodeFinalFrame = function() {
     var finalFrameBuffers = [];
     for ( var i = 0; i < this.numberOfChannels; ++i ) {
-      finalFrameBuffers.push( new Float32Array( this.bufferLength - (this.resampleBufferIndex / this.numberOfChannels) ));
+      finalFrameBuffers.push( new Float32Array( (this.resampleBufferLength - this.resampleBufferIndex) / this.numberOfChannels ));
     }
     this.encode( finalFrameBuffers );
     this.headerType += 4;

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -26,6 +26,7 @@ var root = (typeof self === 'object' && self.self === self && self) || (typeof g
     this.config.encoderSampleRate = config.encoderSampleRate || 48000;
     this.config.encoderPath = config.encoderPath || 'encoderWorker.min.js';
     this.config.streamPages = config.streamPages || false;
+    this.config.rawPacket = config.rawPacket || false;
     this.config.leaveStreamOpen = config.leaveStreamOpen || false;
     this.config.maxBuffersPerPage = config.maxBuffersPerPage || 40;
     this.config.encoderApplication = config.encoderApplication || 2049;
@@ -148,7 +149,13 @@ var root = (typeof self === 'object' && self.self === self && self) || (typeof g
       var that = this;
       this.encoder = new global.Worker( this.config.encoderPath );
 
-      if (this.config.streamPages){
+      if (this.config.rawPacket){
+        this.encoder.addEventListener( "message", function ( e ) {
+          that.streamPage( e.data );
+        });
+      }
+
+      else if (this.config.streamPages){
         this.encoder.addEventListener( "message", function( e ) {
           that.streamPage( e.data );
         });


### PR DESCRIPTION
Encoder and decoder were slightly modified to accept rawPacket option, which bypasses ogg page handling. Opus packet relies on underlying framing mechanics, ogg is good choice but we have websocket.
Encoder and decoder should behave the same without rawPacket option.
Interceptor example can be easily modified to hook websocket with either rawPacket or ogg page.

I've added '_exp2' to DEFAULT_EXPORTS in Makefile. I've built emscripten-fastcomp from source. Without special config, emcc with --llvm-lto 1 removes _exp2.

Compiled scripts in dist were not updated. Maybe you would want to update them yourself.
And you could checkout my raw_packet_dist branch for a quick look.