### PR TITLE
use robust getUserMedia polyfill. fix chrome deprecation warning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opus-recorder",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1640,14 +1640,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1656,6 +1648,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -1787,6 +1787,11 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
+    },
+    "get-user-media-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-user-media-promise/-/get-user-media-promise-1.1.1.tgz",
+      "integrity": "sha1-NVdNFxjnOhY90kAYZbRM7f2Tlfg="
     },
     "glob": {
       "version": "7.1.1",
@@ -3054,15 +3059,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3094,6 +3090,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "sinon": "^2.4.1",
     "sinon-chai": "^2.12.0",
     "webpack": "^3.5.1"
+  },
+  "dependencies": {
+    "get-user-media-promise": "^1.1.1"
   }
 }

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,5 +1,8 @@
 "use strict";
 
+var getUserMedia = require("get-user-media-promise");
+
+
 var Recorder = function( config ){
 
   var that = this;
@@ -40,9 +43,7 @@ var Recorder = function( config ){
 };
 
 Recorder.isRecordingSupported = function(){
-  var AudioContext = global.AudioContext || global.webkitAudioContext;
-  var getUserMedia = global.navigator && ( global.navigator.getUserMedia || ( global.navigator.mediaDevices && global.navigator.mediaDevices.getUserMedia ) );
-  return AudioContext && getUserMedia;
+  return (global.AudioContext || global.webkitAudioContext) && getUserMedia.isSupported;
 };
 
 Recorder.prototype.addEventListener = function( type, listener, useCapture ){
@@ -104,15 +105,7 @@ Recorder.prototype.initStream = function(){
     return global.Promise.resolve( this.stream );
   }
 
-  if ( global.navigator.mediaDevices && global.navigator.mediaDevices.getUserMedia ) {
-    return global.navigator.mediaDevices.getUserMedia( constraints ).then( onStreamInit, onStreamError );
-  }
-
-  if ( global.navigator.getUserMedia ) {
-    return new global.Promise( function( resolve, reject ) {
-      global.navigator.getUserMedia( constraints, resolve, reject );
-    }).then( onStreamInit, onStreamError );
-  }
+  return getUserMedia(constraints).then( onStreamInit, onStreamError );
 };
 
 Recorder.prototype.pause = function(){

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -127,7 +127,13 @@ Recorder.prototype.resume = function() {
 };
 
 Recorder.prototype.setMonitorGain = function( gain ){
-  this.monitorNode.gain.value = gain;
+  // chrome has deprecated dezippering in M63, and will remove it in M64
+  // https://www.chromestatus.com/features/5287995770929152
+  if(this.monitorNode.gain.setTargetAtTime) {
+    this.monitorNode.gain.setTargetAtTime(gain, audioContext.currentTime, 0.01);
+  } else {
+    this.monitorNode.gain.value = gain;
+  }
 };
 
 Recorder.prototype.start = function(){


### PR DESCRIPTION
https://www.npmjs.com/package/get-user-media-promise offers some robust getUserMedia handling. 

In Chrome 63, audio dezippering is deprecated. It will be a breaking change in Chrome 64 (the next release.) see https://www.chromestatus.com/features/5287995770929152 