### PR TITLE
Fixed typo on bitrate option in example

### DIFF
--- a/example/encoder.html
+++ b/example/encoder.html
@@ -68,7 +68,7 @@
       recorder = new Recorder({
         monitorGain: parseInt(monitorGain.value, 10),
         numberOfChannels: parseInt(numberOfChannels.value, 10),
-        bitRate: parseInt(bitRate.value,10),
+        encoderBitRate: parseInt(bitRate.value,10),
         encoderSampleRate: parseInt(encoderSampleRate.value,10),
         encoderPath: "../dist/encoderWorker.min.js"
       });


### PR DESCRIPTION
Hello,
Thank you for this great library. I just noticed that changing bitrate in the encoder example code didn't have any effect. And the reason was a slight mistake ;)
  
  
  